### PR TITLE
Implement basic filters and MCP skeleton

### DIFF
--- a/vaers-analyzer/apps/mcp-server/package.json
+++ b/vaers-analyzer/apps/mcp-server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@vaers/mcp-server",
+  "version": "0.0.1",
+  "private": true,
+  "main": "./src/server.ts",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "start": "node dist/server.js",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "@vaers/mcp-tools": "workspace:^"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.4",
+    "@types/express": "^4.17.21",
+    "@types/node": "^22.15.3",
+    "typescript": "5.8.2"
+  }
+}

--- a/vaers-analyzer/apps/mcp-server/src/server.ts
+++ b/vaers-analyzer/apps/mcp-server/src/server.ts
@@ -1,0 +1,22 @@
+import express from 'express';
+import cors from 'cors';
+import { fdaTools, ToolName } from '@vaers/mcp-tools';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.post('/fda', (req, res) => {
+  const { tool, params } = req.body as { tool: ToolName; params: any };
+  if (!tool || !(tool in fdaTools)) {
+    return res.status(400).json({ error: 'Invalid tool' });
+  }
+
+  // Placeholder implementation that simply echoes params
+  res.json({ tool, params, result: null });
+});
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => {
+  console.log(`MCP server listening on port ${port}`);
+});

--- a/vaers-analyzer/apps/mcp-server/tsconfig.json
+++ b/vaers-analyzer/apps/mcp-server/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/typescript-config/node.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/vaers-analyzer/apps/web/app/reports/components/ReportsHeader.tsx
+++ b/vaers-analyzer/apps/web/app/reports/components/ReportsHeader.tsx
@@ -1,13 +1,40 @@
+"use client";
+
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState, useEffect } from 'react';
 import { PageHeader, Card, CardContent, IconContainer, Input, Select, Label } from '@repo/ui';
+import type { ReportFilters } from '../../actions/reports';
 
 interface ReportsHeaderProps {
   totalReports: number;
   reportsWithOutcomes: number;
   recentReports: number;
+  filters: ReportFilters;
+  limit: number;
 }
 
-export function ReportsHeader({ totalReports, reportsWithOutcomes, recentReports }: ReportsHeaderProps) {
+export function ReportsHeader({ totalReports, reportsWithOutcomes, recentReports, filters, limit }: ReportsHeaderProps) {
+  const router = useRouter();
+  const [search, setSearch] = useState(filters.search ?? "");
+  const [vaccineType, setVaccineType] = useState(filters.vaccineType ?? "");
+  const [outcome, setOutcome] = useState(filters.outcome ?? "");
+  const [dateRange, setDateRange] = useState(filters.dateRange ?? "");
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      const params = new URLSearchParams();
+      if (search) params.set('search', search);
+      if (vaccineType) params.set('vaccineType', vaccineType);
+      if (outcome) params.set('outcome', outcome);
+      if (dateRange) params.set('dateRange', dateRange);
+      params.set('page', '1');
+      params.set('limit', String(limit));
+      router.push(`/reports?${params.toString()}`);
+    }, 300);
+
+    return () => clearTimeout(timeout);
+  }, [search, vaccineType, outcome, dateRange, limit, router]);
   return (
     <div className="mb-12">
       <PageHeader
@@ -108,11 +135,13 @@ export function ReportsHeader({ totalReports, reportsWithOutcomes, recentReports
               <Input
                 type="text"
                 placeholder="VAERS ID, symptoms..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
               />
             </div>
             <div>
               <Label className="mb-2">Vaccine Type</Label>
-              <Select>
+              <Select value={vaccineType} onChange={(e) => setVaccineType(e.target.value)}>
                 <option value="">All Types</option>
                 <option value="covid19">COVID-19</option>
                 <option value="flu">Influenza</option>
@@ -122,7 +151,7 @@ export function ReportsHeader({ totalReports, reportsWithOutcomes, recentReports
             </div>
             <div>
               <Label className="mb-2">Outcome</Label>
-              <Select>
+              <Select value={outcome} onChange={(e) => setOutcome(e.target.value)}>
                 <option value="">All Outcomes</option>
                 <option value="recovered">Recovered</option>
                 <option value="hospitalized">Hospitalized</option>
@@ -131,7 +160,7 @@ export function ReportsHeader({ totalReports, reportsWithOutcomes, recentReports
             </div>
             <div>
               <Label className="mb-2">Date Range</Label>
-              <Select>
+              <Select value={dateRange} onChange={(e) => setDateRange(e.target.value)}>
                 <option value="">All Time</option>
                 <option value="7days">Last 7 days</option>
                 <option value="30days">Last 30 days</option>

--- a/vaers-analyzer/apps/web/app/reports/page.tsx
+++ b/vaers-analyzer/apps/web/app/reports/page.tsx
@@ -1,4 +1,4 @@
-import { getReports } from '../actions/reports';
+import { getReports, type ReportFilters } from '../actions/reports';
 import { ReportsHeader } from './components/ReportsHeader';
 import { ReportList } from './components/ReportList';
 import { Pagination } from './components/Pagination';
@@ -7,14 +7,20 @@ import { PageLayout, PageContainer } from '@repo/ui';
 export default async function ReportsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ page?: string; limit?: string }>;
+  searchParams: Promise<Record<string, string | undefined>>;
 }) {
   const params = await searchParams;
   const page = parseInt(params.page || '1');
   const limit = parseInt(params.limit || '20');
   const offset = (page - 1) * limit;
 
-  const { reports, pagination } = await getReports(limit, offset);
+  const filters: ReportFilters = {
+    search: params.search || undefined,
+    vaccineType: params.vaccineType || undefined,
+    outcome: (params.outcome as ReportFilters['outcome']) || undefined,
+    dateRange: (params.dateRange as ReportFilters['dateRange']) || undefined,
+  };
+  const { reports, pagination } = await getReports(limit, offset, true, filters);
   const totalPages = Math.ceil(pagination.total / limit);
 
   // Calculate real statistics
@@ -29,10 +35,12 @@ export default async function ReportsPage({
   return (
     <PageLayout>
       <PageContainer size="wide">
-        <ReportsHeader 
+        <ReportsHeader
           totalReports={totalReports}
           reportsWithOutcomes={reportsWithOutcomes}
           recentReports={recentReports}
+          filters={filters}
+          limit={limit}
         />
         <ReportList reports={reports} />
         <Pagination

--- a/vaers-analyzer/packages/analyzer/package.json
+++ b/vaers-analyzer/packages/analyzer/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@vaers/analyzer",
+  "version": "0.0.1",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "private": true,
+  "license": "MIT",
+  "dependencies": {
+    "@vaers/mcp-tools": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.3",
+    "typescript": "5.8.2"
+  },
+  "scripts": {
+    "build": "tsc --build"
+  }
+}

--- a/vaers-analyzer/packages/analyzer/src/index.ts
+++ b/vaers-analyzer/packages/analyzer/src/index.ts
@@ -1,0 +1,1 @@
+export { MCPClient } from './mcp-client';

--- a/vaers-analyzer/packages/analyzer/src/mcp-client.ts
+++ b/vaers-analyzer/packages/analyzer/src/mcp-client.ts
@@ -1,0 +1,23 @@
+import type { ToolName, ToolParams } from '@vaers/mcp-tools';
+
+export class MCPClient {
+  private baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl;
+  }
+
+  async call<T extends ToolName>(tool: T, params: ToolParams<T>): Promise<unknown> {
+    const response = await fetch(`${this.baseUrl}/fda`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tool, params })
+    });
+
+    if (!response.ok) {
+      throw new Error(`MCP request failed: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+}

--- a/vaers-analyzer/packages/analyzer/src/pipeline.ts
+++ b/vaers-analyzer/packages/analyzer/src/pipeline.ts
@@ -1,0 +1,29 @@
+import type { VaersReport } from '@vaers/types';
+import { MCPClient } from './mcp-client';
+
+export interface AnalysisStep {
+  id: number;
+  title: string;
+  status: 'pending' | 'in-progress' | 'complete';
+}
+
+export class VaersAnalysisPipeline {
+  constructor(private mcp: MCPClient) {}
+
+  async analyze(report: VaersReport, onStep?: (step: AnalysisStep) => void) {
+    const steps: AnalysisStep[] = [
+      { id: 1, title: 'Extracting key info', status: 'pending' },
+      { id: 2, title: 'Searching FDA database', status: 'pending' }
+    ];
+
+    for (const step of steps) {
+      step.status = 'in-progress';
+      onStep?.(step);
+      // TODO: call MCP and perform analysis
+      step.status = 'complete';
+      onStep?.(step);
+    }
+
+    return { success: true };
+  }
+}

--- a/vaers-analyzer/packages/analyzer/tsconfig.json
+++ b/vaers-analyzer/packages/analyzer/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/typescript-config/node.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/vaers-analyzer/packages/mcp-tools/package.json
+++ b/vaers-analyzer/packages/mcp-tools/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@vaers/mcp-tools",
+  "version": "0.0.1",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "private": true,
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^22.15.3",
+    "typescript": "5.8.2"
+  },
+  "scripts": {
+    "build": "tsc --build"
+  }
+}

--- a/vaers-analyzer/packages/mcp-tools/src/index.ts
+++ b/vaers-analyzer/packages/mcp-tools/src/index.ts
@@ -1,0 +1,21 @@
+export const fdaTools = {
+  searchValidatedSymptoms: {
+    description: "Search FDA validated symptoms for a vaccine",
+    parameters: {
+      vaccine: { type: "string" },
+      symptoms: { type: "array", items: { type: "string" } }
+    }
+  },
+  getControlledTrialData: {
+    description: "Get controlled trial text for deeper analysis",
+    parameters: {
+      vaccine: { type: "string" },
+      indication: { type: "string" }
+    }
+  }
+} as const;
+
+export type ToolName = keyof typeof fdaTools;
+export type ToolParams<T extends ToolName> = {
+  [K in keyof typeof fdaTools[T]["parameters"]]: any;
+};

--- a/vaers-analyzer/packages/mcp-tools/tsconfig.json
+++ b/vaers-analyzer/packages/mcp-tools/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/typescript-config/node.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add interactive filters on reports page
- support filtering in report queries
- start MCP integration package and simple server
- expose MCP client

## Testing
- `pnpm lint` *(fails: connect ENETUNREACH)*
- `pnpm check-types` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_683e67c34454832e9158a8e74912db2f